### PR TITLE
Update gemstash image to latest stable version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM ruby:2.3
-MAINTAINER devops@airhelp.com
+FROM ruby:2.6
 
 ENV RACK_ENV production
-ENV GEMSTASH_VERSION=1.0.3
+ENV GEMSTASH_VERSION=2.0.0
 
 EXPOSE 9292
 


### PR DESCRIPTION
sensu alert:
```
Old docker image
CRITICAL: airhelp/gemstash:latest is very old: 2016-10-26
```

looks good:
```
docker build -t airhelp/gemstash .
Sending build context to Docker daemon  90.62kB
Step 1/7 : FROM ruby:2.6
2.6: Pulling from library/ruby
8f0fdd3eaac0: Already exists
d918eaefd9de: Already exists
43bf3e3107f5: Already exists
27622921edb2: Already exists
dcfa0aa1ae2c: Pull complete
0e1f1dc37f65: Pull complete
c76a82442849: Pull complete
5161fd3df3c4: Pull complete
Digest: sha256:f38fce2b70ba23e90d6397995bea8419b86dd3f20b73846681adb52c63c0b002
Status: Downloaded newer image for ruby:2.6
 ---> a161c3e3dda8
Step 2/7 : MAINTAINER devops@airhelp.com
 ---> Running in f61fff53b95e
Removing intermediate container f61fff53b95e
 ---> 9784b5ba516f
Step 3/7 : ENV RACK_ENV production
 ---> Running in 20758edf1b7c
Removing intermediate container 20758edf1b7c
 ---> d8dd6120f087
Step 4/7 : ENV GEMSTASH_VERSION=2.0.0
 ---> Running in 98e584750bc8
Removing intermediate container 98e584750bc8
 ---> b68d5e8d86d1
Step 5/7 : EXPOSE 9292
 ---> Running in 6fa1bf2574bd
Removing intermediate container 6fa1bf2574bd
 ---> 5500e28fce56
Step 6/7 : RUN gem install gemstash --version $GEMSTASH_VERSION
 ---> Running in 3786bec884f1
Building native extensions. This could take a while...
Successfully installed sqlite3-1.4.2
Successfully installed thor-0.20.3
Successfully installed rack-2.1.2
Successfully installed tilt-2.0.10
Successfully installed rack-protection-2.0.8.1
Successfully installed ruby2_keywords-0.0.2
Successfully installed mustermann-1.1.1
Successfully installed sinatra-2.0.8.1
Successfully installed sequel-5.28.0
Successfully installed server_health_check-1.0.2
Successfully installed server_health_check-rack-0.1.0
Building native extensions. This could take a while...
Successfully installed puma-3.12.2
Successfully installed lru_redux-1.1.0
Successfully installed multipart-post-2.1.1
Successfully installed faraday-0.17.3
Successfully installed faraday_middleware-0.14.0
  5 Update gemstash image to latest stable version¬
Successfully installed dalli-2.7.10
Successfully installed concurrent-ruby-1.1.5

HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

If you are upgrading your Rails application from an older version of Rails:

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.

If you are starting a NEW Rails application, you can ignore this notice.

For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0

Successfully installed i18n-1.8.2
Successfully installed thread_safe-0.3.6
Successfully installed tzinfo-1.2.6
Successfully installed activesupport-5.2.4.1
Successfully installed gemstash-2.0.0
23 gems installed
Removing intermediate container 3786bec884f1
 ---> 744f31b17cbe
Step 7/7 : CMD ["gemstash", "start", "--no-daemonize"]
 ---> Running in 7a4b4d4e5d07
Removing intermediate container 7a4b4d4e5d07
 ---> c2a99b9ef2c5
Successfully built c2a99b9ef2c5
Successfully tagged airhelp/gemstash:latest
```